### PR TITLE
Allow headers to be omitted from response

### DIFF
--- a/lib/delivery/responses/response_base.rb
+++ b/lib/delivery/responses/response_base.rb
@@ -15,9 +15,9 @@ module Kentico
           # * *Args*:
           #   - *http_code* (+integer+) The status code returned by the REST request
           #   - *message* (+string+) An informative message about the response, visible when calling +to_s+
-          #   - *headers* (+hash+) The headers of the REST response
+          #   - *headers* (+hash+) _optional_ The headers of the REST response
           #   - *json* (+string+) _optional_ The complete, unmodified JSON response from the server
-          def initialize(http_code, message, headers, json = '')
+          def initialize(http_code, message, headers = {}, json = '')
             self.http_code = http_code
             self.message = message
             self.headers = headers

--- a/lib/delivery/version.rb
+++ b/lib/delivery/version.rb
@@ -1,7 +1,7 @@
 module Kentico
   module Kontent
     module Delivery
-      VERSION = '2.0.16'.freeze
+      VERSION = '2.0.17'.freeze
     end
   end
 end


### PR DESCRIPTION
### Motivation

`ResponseBase` is initialised with only two arguments in a few places (e.g. https://github.com/Kentico/kontent-delivery-sdk-ruby/blob/5d3f29d0f870f78f8298285c07bc5fcfd56e9fe4/lib/delivery/client/request_manager.rb#L57) when it currently requires at least three arguments. This causes the error handling logic to raise an `ArgumentError` instead of returning a `ResponseBase` as expected.

This can be reproduced with the following code

```ruby
dc = Kentico::Kontent::Delivery::DeliveryClient.new(project_id: '123')
dc.item('123').execute
```

which results in

```
ArgumentError (wrong number of arguments (given 2, expected 3..4))
```