### PR TITLE
#56 insufficient depth now returns emtpy array for get links

### DIFF
--- a/kontent-delivery-sdk-ruby.gemspec
+++ b/kontent-delivery-sdk-ruby.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'kontent-delivery-sdk-ruby'
-  spec.version       = '2.0.22'
+  spec.version       = '2.0.24'
   spec.authors       = ['Eric Dugre']
   spec.email         = ['EricD@kentico.com']
   spec.summary       = 'Kentico Kontent Delivery SDK for Ruby'

--- a/kontent-delivery-sdk-ruby.gemspec
+++ b/kontent-delivery-sdk-ruby.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'kontent-delivery-sdk-ruby'
-  spec.version       = '2.0.24'
+  spec.version       = '2.0.25'
   spec.authors       = ['Eric Dugre']
   spec.email         = ['EricD@kentico.com']
   spec.summary       = 'Kentico Kontent Delivery SDK for Ruby'

--- a/lib/delivery/resolvers/linked_item_resolver.rb
+++ b/lib/delivery/resolvers/linked_item_resolver.rb
@@ -28,7 +28,13 @@ module Kentico
 
           def resolve_item(codename)
             item = @modular_content.values.find { |i| i['system']['codename'] == codename }
-            ContentItem.new JSON.parse(JSON.generate(item)), @content_link_url_resolver, @inline_content_item_resolver, self
+            unless item.nil?
+              return ContentItem.new(JSON.parse(JSON.generate(item)),
+                                     @content_link_url_resolver,
+                                     @inline_content_item_resolver,
+                                     self)
+            end
+            nil
           end
         end
       end


### PR DESCRIPTION
Fixes #56

Content items not found in modular_content now return `nil` in `LinkedItemResolver.resolve_item` instead of throwing an Exception